### PR TITLE
osx-drawElements: temp fix for that inexplicable GL error 1282 on Mac OS

### DIFF
--- a/src/include/Algo3D.hh
+++ b/src/include/Algo3D.hh
@@ -4,7 +4,7 @@
 
 #include <Algorithm.hh>
 
-using VertIndices = std::vector<unsigned int>;
+using VertIndices = std::vector<GLuint>;
 
 class Algo3D : public Algorithm {
 public:

--- a/src/include/Scene3D.hh
+++ b/src/include/Scene3D.hh
@@ -7,7 +7,7 @@
 
 struct Scene3DContext {
     Scene3DContext(size_t w, size_t h, size_t d)
-        : vao(0), vbo(0),
+        : vao(0), vbo(0), elements(0),
           width(w), height(h), depth(d),
           n_points(width * height * depth),
           vertices_size(n_points * 3 * sizeof (GLfloat)),
@@ -33,6 +33,7 @@ struct Scene3DContext {
 
     GLuint vao;
     GLuint vbo;
+    GLuint elements;
 
     size_t  width;
     size_t  height;

--- a/src/include/Scene3D.hh
+++ b/src/include/Scene3D.hh
@@ -16,7 +16,10 @@ struct Scene3DContext {
           vertices(new GLfloat[vertices_size]),
           colors(new GLfloat[colors_size]),
           degreesRotated(0.0f), rotationEnabled(false), program(NULL)
-        {}
+        {
+            // selected.reserve(n_points);
+        }
+
     ~Scene3DContext() {
         delete[] vertices;
         delete[] colors;

--- a/src/miners/GlfwManager.cc
+++ b/src/miners/GlfwManager.cc
@@ -86,15 +86,13 @@ GlfwManager::init()
 }
 
 void
-GlfwManager::glInit()
-{
+GlfwManager::glInit() {
     glewExperimental = GL_TRUE; //stops glew from crashing on OSX :-/
     if (glewInit() != GLEW_OK)
         throw std::runtime_error("!glewInit");
 
     // GLEW throws some errors, so discard all the errors so far
-    //while (glGetError() != GL_NO_ERROR) {}
-    glProcessErrors();
+    glProcessErrors(true);
 
     std::cout << "OpenGL version: " << glGetString(GL_VERSION) << std::endl;
     std::cout << "GLSL version: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
@@ -106,8 +104,7 @@ GlfwManager::glInit()
 }
 
 void
-GlfwManager::glProcessErrors(bool quiet)
-{
+GlfwManager::glProcessErrors(bool quiet) {
     while (true) {
         GLenum error = glGetError();
         if (error == GL_NO_ERROR)
@@ -118,8 +115,7 @@ GlfwManager::glProcessErrors(bool quiet)
 }
 
 void
-GlfwManager::run()
-{
+GlfwManager::run() {
     if (scene_->type() == SCENE_3D)
         glfwSetInputMode(window_, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 

--- a/src/miners/GlfwManager.cc
+++ b/src/miners/GlfwManager.cc
@@ -65,7 +65,7 @@ GlfwManager::init()
         monitor = glfwGetPrimaryMonitor();
     }
 
-    window_ = glfwCreateWindow(args_->width, args_->height, "points", monitor, NULL);
+    window_ = glfwCreateWindow(args_->width, args_->height, "miners", monitor, NULL);
     if (!window_)
         throw std::runtime_error("!glfwCreateWindow. Can your hardware handle OpenGL 3.2?");
 

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -156,8 +156,12 @@ Scene3D::render()
     // bind the VAO
     glBindVertexArray(ctx_.vao);
 
+#ifdef __APPLE__
+    glDrawArrays(GL_POINTS, 0, ctx_.n_points);
+#else
     // draw only the VAO's points we colored
     glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, ctx_.selected.data());
+#endif
 
     // unbind the VAO and the program
     glBindVertexArray(0);

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -74,6 +74,7 @@ Scene3D::reload()
     algo->apply(ctx_.vertices, ctx_.colors, ctx_.selected, ctx_.width, ctx_.height, ctx_.depth)
         || std::cerr << "!apply" << std::endl;
     std::cout << "#points: " << ctx_.selected.size() << std::endl;
+    ctx_.selected.shrink_to_fit();
     load_buffers();
     glBindVertexArray(ctx_.vao);
     glBindBuffer(GL_ARRAY_BUFFER, ctx_.colors_id);
@@ -96,6 +97,7 @@ Scene3D::load(Algorithm* algorithm)
     algo->apply(ctx_.vertices, ctx_.colors, ctx_.selected, ctx_.width, ctx_.height, ctx_.depth)
         || std::cerr << "!apply" << std::endl;
     std::cout << "#points: " << ctx_.selected.size() << std::endl;
+    ctx_.selected.shrink_to_fit();
     load_buffers();
 
     camera_.setPosition(glm::vec3(0, 0, 4));

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -31,6 +31,10 @@ Scene3D::load_buffers() {
     glVertexAttribPointer(ctx_.program->attrib("vert"), 3, GL_FLOAT, GL_FALSE, 0, NULL);
     glEnableVertexAttribArray(ctx_.program->attrib("vert"));
 
+    glGenBuffers(1, &ctx_.elements);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx_.elements);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, ctx_.selected.size(), ctx_.selected.data(), GL_STATIC_DRAW);
+
     // make and bind the VBO
     glGenBuffers(1, &ctx_.colors_id);
     glBindBuffer(GL_ARRAY_BUFFER, ctx_.colors_id);
@@ -156,10 +160,10 @@ Scene3D::render()
     // bind the VAO
     glBindVertexArray(ctx_.vao);
 
-#ifdef __APPLE__
-    glDrawArrays(GL_POINTS, 0, ctx_.n_points);
-#else
     // draw only the VAO's points we colored
+#ifdef __APPLE__
+    glDrawRangeElements(GL_POINTS, ctx_.selected.front(), ctx_.selected.back(), ctx_.selected.size(), GL_UNSIGNED_INT, 0);
+#else
     glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, ctx_.selected.data());
 #endif
 

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -60,6 +60,7 @@ Scene3D::unload()
     if (ctx_.program) {
         delete ctx_.program;
         glDeleteBuffers(1, &ctx_.vbo);
+        glDeleteBuffers(1, &ctx_.elements);
         glDeleteBuffers(1, &ctx_.colors_id);
         glDeleteVertexArrays(1, &ctx_.vao);
     }

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <stdexcept>
+#include <algorithm>
 
 #include <platform.hpp>
 
@@ -33,7 +34,7 @@ Scene3D::load_buffers() {
 
     glGenBuffers(1, &ctx_.elements);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx_.elements);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, ctx_.selected.size(), ctx_.selected.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(decltype(ctx_.selected)::value_type) * ctx_.selected.size(), ctx_.selected.data(), GL_STATIC_DRAW);
 
     // make and bind the VBO
     glGenBuffers(1, &ctx_.colors_id);
@@ -164,12 +165,8 @@ Scene3D::render()
     glBindVertexArray(ctx_.vao);
 
     // draw only the VAO's points we colored
-#ifdef __APPLE__
     auto mM = std::minmax_element(ctx_.selected.begin(), ctx_.selected.end());
-    glDrawRangeElements(GL_POINTS, *mM.first, *mM.second, ctx_.selected.size(), GL_UNSIGNED_INT, 0);
-#else
-    glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, ctx_.selected.data());
-#endif
+    glDrawRangeElements(GL_POINTS, *mM.first, *mM.second, ctx_.selected.size(), GL_UNSIGNED_INT, NULL);
 
     // unbind the VAO and the program
     glBindVertexArray(0);

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -163,7 +163,8 @@ Scene3D::render()
 
     // draw only the VAO's points we colored
 #ifdef __APPLE__
-    glDrawRangeElements(GL_POINTS, ctx_.selected.front(), ctx_.selected.back(), ctx_.selected.size(), GL_UNSIGNED_INT, 0);
+    // glDrawRangeElements(GL_POINTS, ctx_.selected.front(), ctx_.selected.back(), ctx_.selected.size(), GL_UNSIGNED_INT, 0);
+    glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, 0);
 #else
     glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, ctx_.selected.data());
 #endif

--- a/src/miners/Scene3D.cc
+++ b/src/miners/Scene3D.cc
@@ -163,8 +163,8 @@ Scene3D::render()
 
     // draw only the VAO's points we colored
 #ifdef __APPLE__
-    // glDrawRangeElements(GL_POINTS, ctx_.selected.front(), ctx_.selected.back(), ctx_.selected.size(), GL_UNSIGNED_INT, 0);
-    glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, 0);
+    auto mM = std::minmax_element(ctx_.selected.begin(), ctx_.selected.end());
+    glDrawRangeElements(GL_POINTS, *mM.first, *mM.second, ctx_.selected.size(), GL_UNSIGNED_INT, 0);
 #else
     glDrawElements(GL_POINTS, ctx_.selected.size(), GL_UNSIGNED_INT, ctx_.selected.data());
 #endif


### PR DESCRIPTION
Temporarily fixes https://github.com/fenollp/miners/issues/25
...until a real OpenGL debugger comes around for OSX 10.12